### PR TITLE
msys2.sane.sh: make it fail on MD5 and SHA1 checksums

### DIFF
--- a/source/saneman/modules/msys2.sane.sh
+++ b/source/saneman/modules/msys2.sane.sh
@@ -4,6 +4,8 @@
 
 module[description]='MSYS2 packages module'
 
+problems[deprecated:md5sums]='failure'
+problems[deprecated:sha1sums]='failure'
 problems[unformatted:pkgdesc]='message'
 problems[unrecognized:depends]='warning'
 


### PR DESCRIPTION
MSYS2/MINGW packages have been converted to SHA256 (or better) earlier this
year, so (and also in general) it'd seem to be a good practice to mark any regressions
to deprecated/insecure checksums as failures.

/cc @Alexpux
